### PR TITLE
feat: find all import paths from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ or
 npm add --save graphql-fragment-import
 ```
 
+### Combining all imports including transient imports in one string
+You can use the function exported from `@graphql-fragment-import/lib/inline-imports` to combine all the fragment definitions
+imported directly and transitively in a `graphql` file.
+
 ```js
 'use strict';
 
@@ -55,6 +59,50 @@ const output = fragmentImport(fileContents, {
 
 output; // contains the grapqhl file, with all imports having been inlined
 ```
+
+In the code example above, `fileContents` is the source code of a .graphql file. The return value is graphql source code
+with all the fragment definitions in it from all the various files imported.
+
+### Helper function for parsing imports for your eslint rule
+You can use one of the function exported from `@graphql-fragment-import/lib/gather-fragment-imports` to find and parse all
+fragment definitions into FragmentDefinition nodes (for eslint) by import line number.
+
+Here's an example of doing so in an eslint rule.
+
+```javascript
+const { gatherFragmentImportsForContext } = require('@graphql-fragment-import/lib/gather-fragment-imports');
+
+{
+  // eslint rule
+  create(context)
+  {
+    return {
+      'Document:exit'() {
+        /**
+         * lineToFragmentNameToBucket is an object whose keys are line numbers and values are objects whose keys are
+         * the fragment names and the parsed eslint node:
+         * {
+         *     1: {
+         *         FooBar: FragmentDefinition,
+         *         Bar: FragmentDefinition
+         *     }
+         * }
+         */
+        const lineToFragmentNameToBucket = gatherFragmentImportsForContext(context, false);
+
+        for (const [lineNumber, fragmentNameToFragment] of Object.entries(lineToFragmentNameToBucket)) {
+          // fragmentName is a string and fragment is the object returned by `fragmentParserGenerator`
+          for (const [fragmentName, fragment] of Object.entries(fragmentNameToFragment)) {
+            // Do something
+          }
+        }
+      }
+    }
+  }
+}
+```
+Your consumer projects will need to hav the `importResolver` and parser setup like configuration in `.eslintrc` provided
+below in the "Usage (ESLint)" section.
 
 ## Usage (ESLint)
 

--- a/eslint-plugin/gather-fragment-imports-for-context.js
+++ b/eslint-plugin/gather-fragment-imports-for-context.js
@@ -1,0 +1,37 @@
+const path = require('path');
+const gatherFragmentImports = require('@graphql-fragment-import/lib/gather-fragment-imports');
+
+/**
+ * Wrapper function to setup most parameters from the context object to call gatherFragmentImports.
+ *
+ * @param {object} context - Context object that was passed to the `create` function of an eslint rule
+ * @param {boolean} throwIfImportNotFound - If set to true, throws error if import not found
+ * @returns {Map<number, Map<string, Object>>}
+ */
+function gatherFragmentImportsForContext(context, throwIfImportNotFound) {
+  let resolveImport;
+
+  let importResolver =
+    Array.isArray(context.options) &&
+    context.options.length > 0 &&
+    context.options[0].importResolver;
+  if (typeof importResolver === 'string') {
+    if (!path.isAbsolute(importResolver)) {
+      throw new Error(`Option "importResolver" must be an absolute path, not "${importResolver}"`);
+    }
+
+    resolveImport = require(importResolver);
+  } else {
+    resolveImport = require('resolve').sync;
+  }
+
+  return gatherFragmentImports({
+    source: context.getSourceCode().text,
+    sourceLocation: context.getFilename(),
+    resolveImport,
+    fragmentParserGenerator: context.parserServices.getFragmentDefinitionsFromSource,
+    throwIfImportNotFound,
+  });
+}
+
+module.exports = gatherFragmentImportsForContext;

--- a/eslint-plugin/tests/gather-fragment-imports-for-context-test.js
+++ b/eslint-plugin/tests/gather-fragment-imports-for-context-test.js
@@ -1,0 +1,54 @@
+'use strict';
+const path = require('path');
+const { expect } = require('chai');
+
+const fragmentCapture = /(fragment (\w*).*\{[\w\n\s]*)\}/gm;
+
+function* fakeParser(src) {
+  let fragmentSnippet;
+
+  while ((fragmentSnippet = fragmentCapture.exec(src)) !== null) {
+    yield {
+      name: {
+        value: fragmentSnippet[2],
+      },
+    };
+  }
+}
+
+function createFakeContext(source, sourceLocation) {
+  return {
+    getSourceCode: () => {
+      return {
+        text: source,
+      };
+    },
+    getFilename: () => {
+      return path.resolve(__dirname, sourceLocation);
+    },
+    parserServices: {
+      getFragmentDefinitionsFromSource: fakeParser,
+    },
+  };
+}
+
+describe('gather-fragment-imports-for-context', function () {
+  const gatherFragmentImportsForContext = require('../gather-fragment-imports-for-context');
+
+  it('empty source should return empty map', function () {
+    const context = createFakeContext('', '../../example/file.graphql');
+    expect(gatherFragmentImportsForContext(context, false)).to.deep.equal(new Map());
+  });
+
+  it('single file import should contain fragment node from there', function () {
+    const context = createFakeContext('#import "./_orange.graphql"', '../../example/file.graphql');
+
+    const fragments = new Map([
+      ['Orange', { name: { value: 'Orange' } }],
+      ['Kiwi', { name: { value: 'Kiwi' } }],
+    ]);
+    expect(gatherFragmentImportsForContext(context, false)).to.deep.equal(
+      new Map([[1, fragments]]),
+    );
+  });
+});

--- a/lib/gather-fragment-imports.js
+++ b/lib/gather-fragment-imports.js
@@ -1,0 +1,58 @@
+const path = require('path');
+
+const inlineImports = require('@graphql-fragment-import/lib/inline-imports');
+
+/**
+ * Helper function to fetch and parse all the direct and transitive imports starting
+ * from the source. Return object is:
+ *
+ * {
+ *     1: {
+ *         FooBar: fragment,
+ *         Bar: fragment
+ *     }
+ * }
+ *
+ * @param {string} source - .graphql source code
+ * @param {string} sourceLocation - File path of the source code
+ * @param {function} resolveImport - This function is used to resolve the path to file for import
+ * @param {function} fragmentParserGenerator - Generator function that is passed source code. Expected to yield objects for each fragment definition
+ * @param {boolean} throwIfImportNotFound - If set to true, throws error if import not found
+ */
+function gatherFragmentImports({
+  source,
+  sourceLocation,
+  resolveImport,
+  fragmentParserGenerator,
+  throwIfImportNotFound,
+}) {
+  /**
+   * {
+   *     1: {
+   *         FooBar: fragment,
+   *         Bar: fragment
+   *     }
+   * }
+   * @type {Map<number, Map<string, object>>}
+   */
+  const lineToFragmentDefinitions = new Map();
+  const importLinesToInlinedSource = inlineImports.lineToImports(source, {
+    resolveOptions: {
+      basedir: path.dirname(sourceLocation),
+    },
+    resolveImport,
+    throwIfImportNotFound,
+  });
+
+  for (const [lineNumber, source] of importLinesToInlinedSource) {
+    const fragmentDefinitionsBucket = lineToFragmentDefinitions[lineNumber] || new Map();
+    for (const fragment of fragmentParserGenerator(source)) {
+      fragmentDefinitionsBucket.set(fragment.name.value, fragment);
+    }
+    lineToFragmentDefinitions.set(lineNumber, fragmentDefinitionsBucket);
+  }
+
+  return lineToFragmentDefinitions;
+}
+
+module.exports = gatherFragmentImports;

--- a/lib/tests/gather-fragment-imports-test.js
+++ b/lib/tests/gather-fragment-imports-test.js
@@ -1,0 +1,178 @@
+'use strict';
+const { assert } = require('chai');
+const path = require('path');
+const fs = require('fs');
+const gatherFragmentImports = require('../gather-fragment-imports');
+const FixturifyProject = require('fixturify-project');
+
+const fragmentCapture = /(fragment (\w*).*\{[\w\n\s]*)\}/gm;
+
+function* fakeParser(src) {
+  let fragmentSnippet;
+
+  while ((fragmentSnippet = fragmentCapture.exec(src)) !== null) {
+    yield {
+      name: {
+        value: fragmentSnippet[2],
+      },
+    };
+  }
+}
+
+describe('gather-fragment-imports', function () {
+  let basedir;
+
+  beforeEach(function () {
+    const project = new FixturifyProject('my-example', '0.0.1', project => {
+      project.files['apple.graphql'] = `
+fragment apple on User {
+  name
+}`;
+      project.files['orange.graphql'] = `
+fragment orange on User {
+  name
+}`;
+      project.files['parent.graphql'] = `
+#import './apple.graphql'
+
+fragment parent on User {
+  name
+}`;
+      project.files['double-import.graphql'] = `
+#import './apple.graphql'
+#import './orange.graphql'
+
+fragment parent on User {
+  name
+}`;
+      project.files['nested-1.graphql'] = `
+#import './nested-2.graphql'
+
+fragment nested1 on User {
+  name
+}`;
+      project.files['nested-2.graphql'] = `
+#import './nested-3.graphql'
+
+fragment nested2 on User {
+  name
+}`;
+      project.files['nested-3.graphql'] = `
+fragment nested3 on User {
+  name
+}`;
+      project.files['nested.graphql'] = `
+#import './nested-1.graphql'
+
+fragment parent on User {
+  name
+}`;
+      project.files['from-dependency.graphql'] = `
+#import 'my-dependency/_dependency-fragment.graphql'
+query {
+  myQuery {
+    ...FromDependency
+  }
+}`;
+      project.files['missing-import.graphql'] = `
+#import 'missing-import.graphql'
+query {
+  myQuery {
+    ...MissingImport
+  }
+}`;
+
+      project.addDependency('my-dependency', '0.0.1', dependency => {
+        dependency.files['_dependency-fragment.graphql'] = `
+fragment FromDependency on User {
+  name
+}`;
+      });
+    });
+    project.writeSync();
+    basedir = project.baseDir;
+  });
+
+  it('handles single import', function () {
+    const result = gatherFragmentImports({
+      source: fs.readFileSync(path.join(basedir, 'parent.graphql'), 'utf8'),
+      sourceLocation: path.join(basedir, 'parent.graphql'),
+      resolveImport: require('resolve').sync,
+      fragmentParserGenerator: fakeParser,
+      throwIfImportNotFound: false,
+    });
+
+    assert.deepEqual(result, new Map([[2, new Map([['apple', { name: { value: 'apple' } }]])]]));
+  });
+
+  it('handles double import', function () {
+    const result = gatherFragmentImports({
+      source: fs.readFileSync(path.join(basedir, 'double-import.graphql'), 'utf8'),
+      sourceLocation: path.join(basedir, 'double-import.graphql'),
+      resolveImport: require('resolve').sync,
+      fragmentParserGenerator: fakeParser,
+      throwIfImportNotFound: false,
+    });
+
+    assert.deepEqual(
+      result,
+      new Map([
+        [2, new Map([['apple', { name: { value: 'apple' } }]])],
+        [3, new Map([['orange', { name: { value: 'orange' } }]])],
+      ]),
+    );
+  });
+
+  it('handles nested imports, 3 fragments for import on line 2', function () {
+    const result = gatherFragmentImports({
+      source: fs.readFileSync(path.join(basedir, 'nested.graphql'), 'utf8'),
+      sourceLocation: path.join(basedir, 'nested.graphql'),
+      resolveImport: require('resolve').sync,
+      fragmentParserGenerator: fakeParser,
+      throwIfImportNotFound: false,
+    });
+
+    assert.deepEqual(
+      result,
+      new Map([
+        [
+          2,
+          new Map([
+            ['nested1', { name: { value: 'nested1' } }],
+            ['nested2', { name: { value: 'nested2' } }],
+            ['nested3', { name: { value: 'nested3' } }],
+          ]),
+        ],
+      ]),
+    );
+  });
+
+  it('handles imports from another package', function () {
+    const result = gatherFragmentImports({
+      source: fs.readFileSync(path.join(basedir, 'from-dependency.graphql'), 'utf8'),
+      sourceLocation: path.join(basedir, 'from-dependency.graphql'),
+      resolveImport: require('resolve').sync,
+      fragmentParserGenerator: fakeParser,
+      throwIfImportNotFound: false,
+    });
+
+    assert.deepEqual(
+      result,
+      new Map([[2, new Map([['FromDependency', { name: { value: 'FromDependency' } }]])]]),
+    );
+  });
+
+  it('throws when there is missing import', function () {
+    const fn = function () {
+      gatherFragmentImports({
+        source: fs.readFileSync(path.join(basedir, 'missing-import.graphql'), 'utf8'),
+        sourceLocation: path.join(basedir, 'missing-import.graphql'),
+        resolveImport: require('resolve').sync,
+        fragmentParserGenerator: fakeParser,
+        throwIfImportNotFound: true,
+      });
+    };
+
+    assert.throws(fn, "Cannot find module 'missing-import.graphql' from");
+  });
+});


### PR DESCRIPTION
# Summary
Adding function that returns absolute paths of files imported stemming from a source file. The path resolver used is `ember-cli-addon-aware-resolver`

# Test
Added unit test