### PR TITLE
Remove graphql dependency

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "chalk": "^4.1.0",
-    "graphql": "^15.3.0",
     "meow": "^7.0.1",
     "mkdirp": "^1.0.4",
     "resolve": "^1.17.0",


### PR DESCRIPTION
Undo `graphql` dependency added here: https://github.com/stefanpenner/graphql-fragment-import/pull/5

It doesn't look like this dependency is actually used directly and is a liability for conflicting with a more recent major version in an application.