### PR TITLE
Add inline test that has fragment files with circular references betw…

### DIFF
--- a/lib/tests/inline-imports-test.js
+++ b/lib/tests/inline-imports-test.js
@@ -45,6 +45,33 @@ query {
   }
 }`;
 
+      project.files['circular-file-reference-1.graphql'] = `
+#import './circular-file-reference-2.graphql'
+fragment a on User {
+  text {
+    ...textFragment
+  }
+}
+fragment b on User2 {
+  text {
+    ...textFragment
+  }
+}`;
+
+      project.files['circular-file-reference-2.graphql'] = `
+#import './circular-file-reference-1.graphql'
+fragment userCollection on UserCollection {
+  user1 {
+    ...a
+  }
+  user2 {
+    ...b
+  }
+}
+fragment textFragment on TextModel {
+  text
+}`;
+
       project.addDependency('my-dependency', '0.0.1', dependency => {
         dependency.files['_dependency-fragment.graphql'] = `
 fragment FromDependency on User {
@@ -143,6 +170,51 @@ fragment cycle on User {
 }
 `);
   }
+
+  it('handle circular file references correctly', function () {
+    const options = { resolveOptions: { basedir } };
+    assertProjectImports(options);
+    expect(
+      inlineImports(
+        `
+#import './circular-file-reference-2.graphql'
+query A {
+  userCollection {
+    ...userCollection
+  }
+}`,
+        options,
+      ),
+    ).to.eql(`
+
+
+fragment a on User {
+  text {
+    ...textFragment
+  }
+}
+fragment b on User2 {
+  text {
+    ...textFragment
+  }
+}
+fragment userCollection on UserCollection {
+  user1 {
+    ...a
+  }
+  user2 {
+    ...b
+  }
+}
+fragment textFragment on TextModel {
+  text
+}
+query A {
+  userCollection {
+    ...userCollection
+  }
+}`);
+  });
 
   it('handles includes correctly', function () {
     let options = { resolveOptions: { basedir } };


### PR DESCRIPTION
…een files

Current cycle test is checking within a file referencing itself.

Add example with a query referencing a fragment file, which referencing another fragment file, which references back.