### PR TITLE
Add alternative API that takes in file path

### DIFF
--- a/eslint-plugin/tests/custom-resolver.js
+++ b/eslint-plugin/tests/custom-resolver.js
@@ -1,6 +1,8 @@
 const path = require('path');
 
 module.exports = function resolveImport(importIdentifier, { basedir }) {
+  console.log('blah')
+  console.log(importIdentifier);
   if (/miss/i.test(importIdentifier)) {
     let err = new Error(`Cannot find module "${importIdentifier}"`);
     err.code = 'MODULE_NOT_FOUND';

--- a/eslint-plugin/tests/custom-resolver.js
+++ b/eslint-plugin/tests/custom-resolver.js
@@ -1,8 +1,6 @@
 const path = require('path');
 
 module.exports = function resolveImport(importIdentifier, { basedir }) {
-  console.log('blah')
-  console.log(importIdentifier);
   if (/miss/i.test(importIdentifier)) {
     let err = new Error(`Cannot find module "${importIdentifier}"`);
     err.code = 'MODULE_NOT_FOUND';

--- a/eslint-plugin/tests/gather-fragment-imports-for-context-test.js
+++ b/eslint-plugin/tests/gather-fragment-imports-for-context-test.js
@@ -1,6 +1,7 @@
 'use strict';
 const path = require('path');
 const { expect } = require('chai');
+const FixturifyProject = require('fixturify-project');
 
 const fragmentCapture = /(fragment (\w*).*\{[\w\n\s]*)\}/gm;
 
@@ -35,6 +36,18 @@ function createFakeContext(source, sourceLocation) {
 
 describe('gather-fragment-imports-for-context', function () {
   const gatherFragmentImportsForContext = require('../gather-fragment-imports-for-context');
+  let basedir;
+
+  beforeEach(function () {
+    const project = new FixturifyProject('my-example', '0.0.1', project => {
+      project.files['example'] = {
+        'file.graphql': '#import "./_orange.graphql"',
+      };
+    });
+
+    project.writeSync();
+    basedir = project.baseDir;
+  });
 
   it('empty source should return empty map', function () {
     const context = createFakeContext('', '../../example/file.graphql');
@@ -42,7 +55,10 @@ describe('gather-fragment-imports-for-context', function () {
   });
 
   it('single file import should contain fragment node from there', function () {
-    const context = createFakeContext('#import "./_orange.graphql"', '../../example/file.graphql');
+    const context = createFakeContext(
+      '#import "./_orange.graphql"',
+      basedir + '/example/file.graphql',
+    );
 
     const fragments = new Map([
       [

--- a/eslint-plugin/tests/gather-fragment-imports-for-context-test.js
+++ b/eslint-plugin/tests/gather-fragment-imports-for-context-test.js
@@ -42,6 +42,15 @@ describe('gather-fragment-imports-for-context', function () {
     const project = new FixturifyProject('my-example', '0.0.1', project => {
       project.files['example'] = {
         'file.graphql': '#import "./_orange.graphql"',
+        '_orange.graphql': `
+          fragment Kiwi on Fruit {
+            id
+          }
+
+          fragment Orange on Fruit {
+            id
+          }
+        `,
       };
     });
 
@@ -51,6 +60,7 @@ describe('gather-fragment-imports-for-context', function () {
 
   it('empty source should return empty map', function () {
     const context = createFakeContext('', '../../example/file.graphql');
+
     expect(gatherFragmentImportsForContext(context, false)).to.deep.equal(new Map());
   });
 
@@ -66,7 +76,7 @@ describe('gather-fragment-imports-for-context', function () {
         {
           name: { value: 'Orange' },
           loc: {
-            filename: path.join(__dirname, '../../example/_orange.graphql'),
+            filename: path.join(basedir, '/example/_orange.graphql'),
           },
         },
       ],
@@ -75,13 +85,15 @@ describe('gather-fragment-imports-for-context', function () {
         {
           name: { value: 'Kiwi' },
           loc: {
-            filename: path.join(__dirname, '../../example/_orange.graphql'),
+            filename: path.join(basedir, '/example/_orange.graphql'),
           },
         },
       ],
     ]);
-    expect(gatherFragmentImportsForContext(context, false)).to.deep.equal(
-      new Map([[1, fragments]]),
-    );
+    const output = gatherFragmentImportsForContext(context, false);
+
+    expect([...output.get(1).keys()]).to.deep.equal(['Kiwi', 'Orange']);
+    expect(output.get(1).get('Kiwi')).to.deep.equal(fragments.get('Kiwi'));
+    expect(output.get(1).get('Orange')).to.deep.equal(fragments.get('Orange'));
   });
 });

--- a/eslint-plugin/tests/validate-imports-test.js
+++ b/eslint-plugin/tests/validate-imports-test.js
@@ -11,134 +11,134 @@ describe('eslint/validate-imports', function () {
     let project, tester;
     project = new Project('my-fake-project', '0.0.0', project => {
       project.files['_my-person.graphql'] = `
-fragment myPerson on People {
-  id
-  name
-}`;
+  fragment myPerson on People {
+    id
+    name
+  }`;
       project.files['_my-fruit.graphql'] = `
-fragment myFruit on Fruit {
-  id
-  colour
-}`;
+  fragment myFruit on Fruit {
+    id
+    colour
+  }`;
 
       project.files['test-file.graphql'] = `
-#import './_my-person.graphql'
-query foo {
-  bar {
-    ...myPerson
-  }
-}`;
+  #import './_my-person.graphql'
+  query foo {
+    bar {
+      ...myPerson
+    }
+  }`;
 
       project.files['test-file-fragment-with-import.graphql'] = `
-#import './_my-person.graphql'
-fragment foo on People {
-  ...myPerson
-  someOtherProperty
-}
-
-query {
-  bar {
-    ...foo
+  #import './_my-person.graphql'
+  fragment foo on People {
+    ...myPerson
+    someOtherProperty
   }
-}
-`;
+
+  query {
+    bar {
+      ...foo
+    }
+  }
+  `;
 
       project.files['no-such-import.graphql'] = `
-#import './_no-such-file.graphql'
-query foo {
-  bar {
-    ...myFragment
+  #import './_no-such-file.graphql'
+  query foo {
+    bar {
+      ...myFragment
+    }
   }
-}
-`;
+  `;
 
       project.files['unused-import.graphql'] = `
-#import './_my-person.graphql'
-query foo {
-  bar {
-    id
-  }
-}`;
+  #import './_my-person.graphql'
+  query foo {
+    bar {
+      id
+    }
+  }`;
 
       project.files['unused-some-import.graphql'] = `
-#import './_my-person.graphql'
-#import './_my-fruit.graphql'
+  #import './_my-person.graphql'
+  #import './_my-fruit.graphql'
 
-query foo {
-  bar {
-    id
-    ...myPerson
-  }
-}`;
+  query foo {
+    bar {
+      id
+      ...myPerson
+    }
+  }`;
 
       project.files['unused-fragment.graphql'] = `
-fragment NotGonnaUseThis on People {
-  id
-}
-
-query {
-  bar {
-    name
+  fragment NotGonnaUseThis on People {
+    id
   }
-}
-    `;
+
+  query {
+    bar {
+      name
+    }
+  }
+      `;
 
       project.files['missing-fragments.graphql'] = `
-#import './_my-person.graphql'
-query foo {
-  bar {
-    ...noSuchFragment,
-    ...myPerson,
-    ...noSuchFragment,
-  }
-}`;
+  #import './_my-person.graphql'
+  query foo {
+    bar {
+      ...noSuchFragment,
+      ...myPerson,
+      ...noSuchFragment,
+    }
+  }`;
 
       project.addDependency('some-dependency', '1.0.0', addon => {
         addon.files['_fragment.graphql'] = `
-fragment MyFragment on Fruit {
-  id
-} `;
+  fragment MyFragment on Fruit {
+    id
+  } `;
       });
 
       project.files['with-node-modules-import.graphql'] = `
-#import './node_modules/some-dependency/_fragment.graphql'
-query foo {
-  bar {
-    ...Fragment
+  #import './node_modules/some-dependency/_fragment.graphql'
+  query foo {
+    bar {
+      ...Fragment
+    }
   }
-}
-      `;
+        `;
 
       project.files['complex.graphql'] = `
-#import './file-without-underscore.graphql'
-#import './_fragment.apple'
-#import './_fragment.graphgql'
-#import './_fragment.grapqhl'
-query foo {
-  bar {
-    ...MyFragment
-    ...myPerson
-  }
-} `;
+  #import './file-without-underscore.graphql'
+  #import './_fragment.apple'
+  #import './_fragment.graphgql'
+  #import './_fragment.grapqhl'
+  query foo {
+    bar {
+      ...MyFragment
+      ...myPerson
+    }
+  } `;
 
       // two errors for the bad spreads on imported fragments
       // the in-document fragment is left to the standard rule, wrapped by @eslint-ast/eslint-plugin-graphql
       project.files['invalid-spread-imported.graphql'] = `
-#import './_my-person.graphql'
-#import './_my-fruit.graphql'
-fragment inDocumentFragment on People {
-  name
-}
-query foo {
-  bar {
-    ...myFruit
-    ...inDocumentFragment
+  #import './_my-person.graphql'
+  #import './_my-fruit.graphql'
+  fragment inDocumentFragment on People {
+    name
   }
-  baz {
-    ...myPerson
-    ...inDocumentFragment
-  }
-} `;
+  query foo {
+    bar {
+      ...myFruit
+      ...inDocumentFragment
+    }
+    baz {
+      ...myPerson
+      ...inDocumentFragment
+    }
+  } `;
     });
 
     project.writeSync();

--- a/lib/gather-fragment-imports.js
+++ b/lib/gather-fragment-imports.js
@@ -66,7 +66,6 @@ function gatherFragmentImports({
     lineToFragmentDefinitions.set(lineNumber, fragmentDefinitionsBucket);
   }
 
-  console.log(lineToFragmentDefinitions);
   return lineToFragmentDefinitions;
 }
 

--- a/lib/gather-fragment-imports.js
+++ b/lib/gather-fragment-imports.js
@@ -36,13 +36,24 @@ function gatherFragmentImports({
    * @type {Map<number, Map<string, object>>}
    */
   const lineToFragmentDefinitions = new Map();
-  const importLinesToInlinedSource = inlineImports.lineToImports(source, {
-    resolveOptions: {
-      basedir: path.dirname(sourceLocation),
-    },
-    resolveImport,
-    throwIfImportNotFound,
-  });
+  let importLinesToInlinedSource;
+  if (source?.length > 0 && sourceLocation !== undefined) {
+    importLinesToInlinedSource = inlineImports.lineToImportsFromFile(sourceLocation, {
+      resolveOptions: {
+        basedir: path.dirname(sourceLocation),
+      },
+      resolveImport,
+      throwIfImportNotFound,
+    });
+  } else {
+    importLinesToInlinedSource = inlineImports.lineToImports(source, {
+      resolveOptions: {
+        basedir: path.dirname(sourceLocation),
+      },
+      resolveImport,
+      throwIfImportNotFound,
+    });
+  }
 
   for (const [lineNumber, { filename, line: source }] of importLinesToInlinedSource) {
     const fragmentDefinitionsBucket = lineToFragmentDefinitions[lineNumber] || new Map();
@@ -55,6 +66,7 @@ function gatherFragmentImports({
     lineToFragmentDefinitions.set(lineNumber, fragmentDefinitionsBucket);
   }
 
+  console.log(lineToFragmentDefinitions);
   return lineToFragmentDefinitions;
 }
 

--- a/lib/inline-imports.js
+++ b/lib/inline-imports.js
@@ -86,17 +86,6 @@ function inlineImports(fileContents, options = {}, visited = new Set()) {
   return result.join('\n');
 }
 
-function getFilename(filePath, options = {}) {
-  const { resolveImport, resolveOptions = {} } = options;
-
-  const { basedir } = resolveOptions;
-  if (typeof basedir !== 'string') {
-    throw new Error('inlineImports requires options.resolverOptions.basedir be set');
-  }
-  const resolve = typeof resolveImport === 'function' ? resolveImport : require('resolve').sync;
-  return resolve(filePath, resolveOptions);
-}
-
 function getFileContents(filePath, options = {}) {
   const { fs } = options;
   const resolvedFs = typeof fs === 'function' ? fs : require('fs');
@@ -109,18 +98,21 @@ function getFileContents(filePath, options = {}) {
  * @typedef {{ basedir: string, ...args: [any]}} ResolverOptions
  * @property {string} basedir - The base directory to use when resolving import identifiers.  For most platforms this will be the absolute path to the directory containing the graphql query file with imports.
  * @property {...args} [any] - any other properties on a `ResolverOptions` will be passed through to the resolver.
- * @param {string} fullFilePath - The graphql document filepath to inline imports into
+ * @param {string} originalFileName - The graphql document filepath to inline imports into
  * @param {object} options
  * @param {(identifier: string, options: ResolverOptions) => string} [options.resolveImport=require.resolve] - a function for resolving imports.  It must support relative paths as well as any package specifiers that may be present as identifiers in the import statements of `fileContents`.  For invalid import identifiers, it should throw an error. Defaults to `resolve.sync` (i.e. treating imported packages as node modules).
  * @param {ResolverOptions} options.resolveOptions - options that are passed to `options.resolveImport` when resolving imports.
  * @param {boolean} [throwIfImportNotFound=true] - whether or not to throw for invalid imports, or to silently ignore them.
  */
-function inlineImportsFromFile(fullFilePath, options = {}) {
+function inlineImportsFromFile(originalFileName, options = {}) {
   const result = [];
-  const filename = getFilename(fullFilePath, options);
-  const fileSource = getFileContents(filename, options);
+  const fileSource = getFileContents(originalFileName, options);
 
-  for (let { line } of linesWithInlinedImportsOf(fileSource, options, new Set([filename]))) {
+  for (let { line } of linesWithInlinedImportsOf(
+    fileSource,
+    options,
+    new Set([originalFileName]),
+  )) {
     result.push(line);
   }
   return result.join('\n');
@@ -144,10 +136,10 @@ module.exports.lineToImports = function (fileContents, options = {}, visited = n
   return result;
 };
 
-module.exports.lineToImportsFromFile = function (fullFilePath, options = {}) {
+module.exports.lineToImportsFromFile = function (originalFileName, options = {}) {
   const result = new Map();
-  const originalFileName = getFilename(fullFilePath, options);
   const fileSource = getFileContents(originalFileName, options);
+
   for (let { line, match, lineNumber, filename } of linesWithInlinedImportsOf(
     fileSource,
     options,

--- a/lib/inline-imports.js
+++ b/lib/inline-imports.js
@@ -86,13 +86,72 @@ function inlineImports(fileContents, options = {}, visited = new Set()) {
   return result.join('\n');
 }
 
+function getFilename(filePath, options = {}) {
+  const { resolveImport, resolveOptions = {} } = options;
+
+  const { basedir } = resolveOptions;
+  if (typeof basedir !== 'string') {
+    throw new Error('inlineImports requires options.resolverOptions.basedir be set');
+  }
+  const resolve = typeof resolveImport === 'function' ? resolveImport : require('resolve').sync;
+  return resolve(filePath, resolveOptions);
+}
+
+function getFileContents(filePath, options = {}) {
+  const { fs } = options;
+  const resolvedFs = typeof fs === 'function' ? fs : require('fs');
+  return resolvedFs.readFileSync(filePath, 'utf8');
+}
+
+/*
+ * Inline any import statements of the graphql document from `fullFilePath`
+ *
+ * @typedef {{ basedir: string, ...args: [any]}} ResolverOptions
+ * @property {string} basedir - The base directory to use when resolving import identifiers.  For most platforms this will be the absolute path to the directory containing the graphql query file with imports.
+ * @property {...args} [any] - any other properties on a `ResolverOptions` will be passed through to the resolver.
+ * @param {string} fullFilePath - The graphql document filepath to inline imports into
+ * @param {object} options
+ * @param {(identifier: string, options: ResolverOptions) => string} [options.resolveImport=require.resolve] - a function for resolving imports.  It must support relative paths as well as any package specifiers that may be present as identifiers in the import statements of `fileContents`.  For invalid import identifiers, it should throw an error. Defaults to `resolve.sync` (i.e. treating imported packages as node modules).
+ * @param {ResolverOptions} options.resolveOptions - options that are passed to `options.resolveImport` when resolving imports.
+ * @param {boolean} [throwIfImportNotFound=true] - whether or not to throw for invalid imports, or to silently ignore them.
+ */
+function inlineImportsFromFile(fullFilePath, options = {}) {
+  const result = [];
+  const filename = getFilename(fullFilePath, options);
+  const fileSource = getFileContents(filename, options);
+
+  for (let { line } of linesWithInlinedImportsOf(fileSource, options, new Set([filename]))) {
+    result.push(line);
+  }
+  return result.join('\n');
+}
+
 module.exports = inlineImports;
+module.exports.inlineImportsFromFile = inlineImportsFromFile;
 module.exports.lineToImports = function (fileContents, options = {}, visited = new Set()) {
   const result = new Map();
   for (let { line, match, lineNumber, filename } of linesWithInlinedImportsOf(
     fileContents,
     options,
     visited,
+  )) {
+    // We're only interested in the inlined import lines, ignore any
+    // non-matching lines
+    if (match) {
+      result.set(lineNumber, { filename, line });
+    }
+  }
+  return result;
+};
+
+module.exports.lineToImportsFromFile = function (fullFilePath, options = {}) {
+  const result = new Map();
+  const originalFileName = getFilename(fullFilePath, options);
+  const fileSource = getFileContents(originalFileName, options);
+  for (let { line, match, lineNumber, filename } of linesWithInlinedImportsOf(
+    fileSource,
+    options,
+    new Set([originalFileName]),
   )) {
     // We're only interested in the inlined import lines, ignore any
     // non-matching lines

--- a/lib/tests/inline-imports-from-file-test.js
+++ b/lib/tests/inline-imports-from-file-test.js
@@ -219,11 +219,6 @@ fragment FromDependency on User {
         return path.join(basedir, 'vendor', '__inlined-fragment');
       }
 
-      if (identifier.startsWith(basedir)) {
-        // full path
-        return identifier;
-      }
-
       throw new Error(`Unexpected resolveImport('${identifier}')`);
     }
 
@@ -236,18 +231,13 @@ fragment FromDependency on User {
 
     assertProjectImports(options);
     expect(resolutions).to.deep.equal([
-      [basedir + '/apple-imports.graphql', basedir],
-      ['./apple.graphql', basedir],
-      [basedir + '/apple-apple-imports.graphql', basedir],
       ['./apple.graphql', basedir],
       ['./apple.graphql', basedir],
-      [basedir + '/apple-orange-imports.graphql', basedir],
+      ['./apple.graphql', basedir],
       ['./apple.graphql', basedir],
       ['./orange.graphql', basedir],
-      [basedir + '/parent-imports.graphql', basedir],
       ['./parent.graphql', basedir],
       ['./apple.graphql', basedir],
-      [basedir + '/cycle-imports.graphql', basedir],
       ['./cycle-1.graphql', basedir],
       ['./cycle-1.graphql', basedir],
     ]);

--- a/lib/tests/inline-imports-from-file-test.js
+++ b/lib/tests/inline-imports-from-file-test.js
@@ -3,7 +3,7 @@ const { expect } = require('chai');
 const path = require('path');
 const inlineImports = require('../inline-imports');
 const FixturifyProject = require('fixturify-project');
-describe('inline-imports', function () {
+describe('inline-imports-from-file', function () {
   let basedir;
 
   beforeEach(function () {
@@ -64,6 +64,38 @@ fragment textFragment on TextModel {
   text
 }`;
 
+      project.files['circular-file-query.graphql'] = `
+#import './circular-file-reference-2.graphql'
+query A {
+  userCollection {
+    ...userCollection
+  }
+}
+`;
+
+      project.files['includes.graphql'] = `
+#import "my-dependency/_dependency-fragment.graphql"`;
+
+      project.files['custom-resolution.graphql'] = `
+#import "@CUSTOM"`;
+
+      project.files['apple-imports.graphql'] = `
+#import './apple.graphql'`;
+
+      project.files['apple-apple-imports.graphql'] = `
+#import './apple.graphql'
+#import './apple.graphql'`;
+
+      project.files['apple-orange-imports.graphql'] = `
+#import './apple.graphql'
+#import './orange.graphql'`;
+
+      project.files['parent-imports.graphql'] = `
+#import './parent.graphql'`;
+
+      project.files['cycle-imports.graphql'] = `
+#import './cycle-1.graphql'`;
+
       project.addDependency('my-dependency', '0.0.1', dependency => {
         dependency.files['_dependency-fragment.graphql'] = `
 fragment FromDependency on User {
@@ -77,48 +109,26 @@ fragment FromDependency on User {
 
   function assertProjectImports(options) {
     expect(inlineImports(``, options)).to.eql(``);
+    expect(inlineImports.inlineImportsFromFile(basedir + '/apple-imports.graphql', options)).to.eql(
+      `
+
+fragment apple on User {
+  name
+}`,
+    );
+
     expect(
-      inlineImports(
-        `
-#import './apple.graphql'
-`,
-        options,
-      ),
+      inlineImports.inlineImportsFromFile(basedir + '/apple-apple-imports.graphql', options),
     ).to.eql(
       `
 
 fragment apple on User {
   name
-}
-`,
+}`,
     );
 
-    expect(
-      inlineImports(
-        `
-#import './apple.graphql'
-#import './apple.graphql'
-`,
-        options,
-      ),
-    ).to.eql(
-      `
-
-fragment apple on User {
-  name
-}
-`,
-    );
-
-    expect(
-      inlineImports(
-        `
-#import './apple.graphql'
-#import './orange.graphql'
-`,
-        options,
-      ),
-    ).to.eql(`
+    expect(inlineImports.inlineImportsFromFile(basedir + '/apple-orange-imports.graphql', options))
+      .to.eql(`
 
 fragment apple on User {
   name
@@ -126,17 +136,10 @@ fragment apple on User {
 
 fragment orange on User {
   name
-}
-`);
+}`);
 
-    expect(
-      inlineImports(
-        `
-#import './parent.graphql'
-`,
-        options,
-      ),
-    ).to.eql(`
+    expect(inlineImports.inlineImportsFromFile(basedir + '/parent-imports.graphql', options)).to
+      .eql(`
 
 
 fragment apple on User {
@@ -145,39 +148,21 @@ fragment apple on User {
 
 fragment parent on User {
   name
-}
-`);
+}`);
 
-    expect(
-      inlineImports(
-        `
-#import './cycle-1.graphql'
-`,
-        options,
-      ),
-    ).to.eql(`
+    expect(inlineImports.inlineImportsFromFile(basedir + '/cycle-imports.graphql', options)).to
+      .eql(`
 
 fragment cycle on User {
   name
-}
-`);
+}`);
   }
 
   it('handle circular file references correctly', function () {
     const options = { resolveOptions: { basedir } };
     assertProjectImports(options);
-    expect(
-      inlineImports(
-        `
-#import './circular-file-reference-2.graphql'
-query A {
-  userCollection {
-    ...userCollection
-  }
-}`,
-        options,
-      ),
-    ).to.eql(`
+    expect(inlineImports.inlineImportsFromFile(basedir + '/circular-file-query.graphql', options))
+      .to.eql(`
 
 
 fragment a on User {
@@ -205,25 +190,18 @@ query A {
   userCollection {
     ...userCollection
   }
-}`);
+}
+`);
   });
 
   it('handles includes correctly', function () {
     let options = { resolveOptions: { basedir } };
     assertProjectImports(options);
-    expect(
-      inlineImports(
-        `
-#import "my-dependency/_dependency-fragment.graphql"
-    `,
-        options,
-      ),
-    ).to.eql(`
+    expect(inlineImports.inlineImportsFromFile(basedir + '/includes.graphql', options)).to.eql(`
 
 fragment FromDependency on User {
   name
-}
-    `);
+}`);
   });
 
   it('supports custom resolution strategies', function () {
@@ -241,6 +219,11 @@ fragment FromDependency on User {
         return path.join(basedir, 'vendor', '__inlined-fragment');
       }
 
+      if (identifier.startsWith(basedir)) {
+        // full path
+        return identifier;
+      }
+
       throw new Error(`Unexpected resolveImport('${identifier}')`);
     }
 
@@ -253,29 +236,27 @@ fragment FromDependency on User {
 
     assertProjectImports(options);
     expect(resolutions).to.deep.equal([
+      [basedir + '/apple-imports.graphql', basedir],
+      ['./apple.graphql', basedir],
+      [basedir + '/apple-apple-imports.graphql', basedir],
       ['./apple.graphql', basedir],
       ['./apple.graphql', basedir],
-      ['./apple.graphql', basedir],
+      [basedir + '/apple-orange-imports.graphql', basedir],
       ['./apple.graphql', basedir],
       ['./orange.graphql', basedir],
+      [basedir + '/parent-imports.graphql', basedir],
       ['./parent.graphql', basedir],
       ['./apple.graphql', basedir],
+      [basedir + '/cycle-imports.graphql', basedir],
       ['./cycle-1.graphql', basedir],
       ['./cycle-1.graphql', basedir],
     ]);
 
-    expect(
-      inlineImports(
-        `
-#import "@CUSTOM"
-    `,
-        options,
-      ),
-    ).to.eql(`
+    expect(inlineImports.inlineImportsFromFile(basedir + '/custom-resolution.graphql', options)).to
+      .eql(`
 
 fragment CustomResolutionFragment on User {
   name
-}
-    `);
+}`);
   });
 });


### PR DESCRIPTION
Add api that takes in filePath and initializes visitor to the original file

TODO Need Help:
Tests for ESLint are failing with this change with path resolution
Question on why source and sourceLocatiton are needed, is source not just sourceLocation.readFileSync?