### PR TITLE
Drop Support for node 10, 12. Support node 14, 16, 18.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
 
     strategy:
       matrix:
-        node: ['10', '12', '14']
+        # maint LTS active LTS current
+        node: ['14', '16', '18']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
Test against current, LTS, Maint LTS.

This is a breaking change as we'll be dropping support for EOL node
versions 12 and 10.
