### PR TITLE
Add util to return string with imports inlined and map of matched imports

### DIFF
--- a/lib/inline-imports.js
+++ b/lib/inline-imports.js
@@ -66,6 +66,38 @@ function* linesWithInlinedImportsOf(
   }
 }
 
+/**
+ * Returns an object containing the query/fragment with all fragements inlined,
+ * as well as the matched imports (effectively, a combination of both the default
+ * `inlineImports` function, and the `lineToImports` utility)
+ *
+ * @name inlineImportsWithLineToImports
+ * @returns {inlineImports: string, lineToImports: Map<number, {filename: string, line: string}>}
+ */
+function inlineImportsWithLineToImports(fileContents, options = {}, visited = new Set()) {
+  const inlineImportsResult = [];
+  const lineToImports = new Map();
+
+  for (let { line, match, lineNumber, filename } of linesWithInlinedImportsOf(
+    fileContents,
+    options,
+    visited,
+  )) {
+    inlineImportsResult.push(line);
+
+    // We're only interested in the inlined import lines, ignore any
+    // non-matching lines
+    if (match) {
+      lineToImports.set(lineNumber, { filename, line });
+    }
+  }
+
+  return {
+    inlineImports: inlineImportsResult.join('\n'),
+    lineToImports,
+  };
+}
+
 /*
  * Inline any import statements of the graphql document string `fileContents`
  *
@@ -79,26 +111,11 @@ function* linesWithInlinedImportsOf(
  * @param {boolean} [throwIfImportNotFound=true] - whether or not to throw for invalid imports, or to silently ignore them.
  */
 function inlineImports(fileContents, options = {}, visited = new Set()) {
-  const result = [];
-  for (let { line } of linesWithInlinedImportsOf(fileContents, options, visited)) {
-    result.push(line);
-  }
-  return result.join('\n');
+  return inlineImportsWithLineToImports(fileContents, options, visited).inlineImports;
 }
 
 module.exports = inlineImports;
+module.exports.inlineImportsWithLineToImports = inlineImportsWithLineToImports;
 module.exports.lineToImports = function (fileContents, options = {}, visited = new Set()) {
-  const result = new Map();
-  for (let { line, match, lineNumber, filename } of linesWithInlinedImportsOf(
-    fileContents,
-    options,
-    visited,
-  )) {
-    // We're only interested in the inlined import lines, ignore any
-    // non-matching lines
-    if (match) {
-      result.set(lineNumber, { filename, line });
-    }
-  }
-  return result;
+  return inlineImportsWithLineToImports(fileContents, options, visited).lineToImports;
 };

--- a/lib/tests/inline-imports-test.js
+++ b/lib/tests/inline-imports-test.js
@@ -2,6 +2,7 @@
 const { expect } = require('chai');
 const path = require('path');
 const inlineImports = require('../inline-imports');
+const { inlineImportsWithLineToImports } = inlineImports;
 const FixturifyProject = require('fixturify-project');
 describe('inline-imports', function () {
   let basedir;
@@ -232,6 +233,63 @@ fragment FromDependency on User {
   name
 }
     `);
+  });
+
+  it('`inlineImportsWithLineToImports` returns correctly for a query with imported fragments', function () {
+    const options = { resolveOptions: { basedir } };
+    assertProjectImports(options);
+
+    const { inlineImports, lineToImports } = inlineImportsWithLineToImports(
+      `
+#import 'my-dependency/_dependency-fragment.graphql'
+query {
+  myQuery {
+    ...FromDependency
+  }
+}`,
+      options,
+    );
+
+    expect(inlineImports).to.eql(`
+
+fragment FromDependency on User {
+  name
+}
+query {
+  myQuery {
+    ...FromDependency
+  }
+}`);
+
+    expect(lineToImports.size).to.eql(1);
+    expect(lineToImports.get(2)).to.deep.eql({
+      filename: path.join(basedir, 'node_modules/my-dependency/_dependency-fragment.graphql'),
+      line: '\nfragment FromDependency on User {\n  name\n}',
+    });
+  });
+
+  it('`inlineImportsWithLineToImports` returns correctly for a query with no imported fragments', function () {
+    const options = { resolveOptions: { basedir } };
+    assertProjectImports(options);
+
+    const { inlineImports, lineToImports } = inlineImportsWithLineToImports(
+      `
+query {
+  myQuery {
+    __typename
+  }
+}`,
+      options,
+    );
+
+    expect(inlineImports).to.eql(`
+query {
+  myQuery {
+    __typename
+  }
+}`);
+
+    expect(lineToImports.size).to.eql(0);
   });
 
   it('supports custom resolution strategies', function () {


### PR DESCRIPTION
Currently to get the string with all imports inlined and matched imports we need to call `inlineImports`, and `lineToImports` separately, effectively needing to incur the cost of `linesWithInlinedImportsOf` twice under the hood. This adds a utility that combines both of these, so the consumer doesn't need to incur this cost. As a result, I have updated both `inlineImports` and `lineToImports` to call this new utility, so the implementation for each isn't duplicated.