### PR TITLE
Ensure transitively imported fragments are accounted for by `inlineImports` and `lineToImports`

### DIFF
--- a/lib/gather-fragment-imports.js
+++ b/lib/gather-fragment-imports.js
@@ -44,15 +44,17 @@ function gatherFragmentImports({
     throwIfImportNotFound,
   });
 
-  for (const [lineNumber, { filename, line: source }] of importLinesToInlinedSource) {
-    const fragmentDefinitionsBucket = lineToFragmentDefinitions[lineNumber] || new Map();
-    for (const fragment of fragmentParserGenerator(source)) {
-      // Augment the FragmentDefinition by adding the resolved file path inside .loc.filename
-      fragment.loc.filename = filename;
+  for (const [lineNumber, importMap] of importLinesToInlinedSource) {
+    for (const [filename, source] of importMap) {
+      const fragmentDefinitionsBucket = lineToFragmentDefinitions[lineNumber] || new Map();
+      for (const fragment of fragmentParserGenerator(source)) {
+        // Augment the FragmentDefinition by adding the resolved file path inside .loc.filename
+        fragment.loc.filename = filename;
 
-      fragmentDefinitionsBucket.set(fragment.name.value, fragment);
+        fragmentDefinitionsBucket.set(fragment.name.value, fragment);
+      }
+      lineToFragmentDefinitions.set(lineNumber, fragmentDefinitionsBucket);
     }
-    lineToFragmentDefinitions.set(lineNumber, fragmentDefinitionsBucket);
   }
 
   return lineToFragmentDefinitions;

--- a/lib/gather-fragment-imports.js
+++ b/lib/gather-fragment-imports.js
@@ -45,8 +45,8 @@ function gatherFragmentImports({
   });
 
   for (const [lineNumber, importMap] of importLinesToInlinedSource) {
+    const fragmentDefinitionsBucket = lineToFragmentDefinitions[lineNumber] || new Map();
     for (const [filename, source] of importMap) {
-      const fragmentDefinitionsBucket = lineToFragmentDefinitions[lineNumber] || new Map();
       for (const fragment of fragmentParserGenerator(source)) {
         // Augment the FragmentDefinition by adding the resolved file path inside .loc.filename
         fragment.loc.filename = filename;

--- a/lib/inline-imports.js
+++ b/lib/inline-imports.js
@@ -50,7 +50,7 @@ function* linesWithInlinedImportsOf(
       }
 
       const fragmentSource = fs.readFileSync(filename, 'utf8');
-      const { inlineImports, lineToImports } = inlineImportsWithLineToImports(
+      const { inlineImports } = inlineImportsWithLineToImports(
         fragmentSource,
         {
           resolveImport: resolve,
@@ -59,11 +59,11 @@ function* linesWithInlinedImportsOf(
           },
         },
         visited,
-        fragmentCollector,
         false,
+        fragmentCollector,
       );
 
-      yield { line: inlineImports, match: true, lineNumber, filename, lineToImports };
+      yield { line: inlineImports, match: true, lineNumber, filename, rawSource: fragmentSource };
     } else {
       yield { line, match: false, lineNumber };
     }
@@ -82,16 +82,15 @@ function inlineImportsWithLineToImports(
   fileContents,
   options = {},
   visited = new Set(),
-  fragmentCollector = new Map(),
   root = true,
-  lineToImports = new Map(),
+  fragmentCollector = new Map(),
 ) {
   const inlineImportsResult = [];
-
+  const lineToImports = new Map();
   /** Ideally lineToImports should look like this:
   // Map<lineNumber, Map<filename,source>>
 **/
-  for (let { line, match, lineNumber, filename } of linesWithInlinedImportsOf(
+  for (let { line, match, lineNumber, filename, rawSource } of linesWithInlinedImportsOf(
     fileContents,
     options,
     visited,
@@ -102,10 +101,11 @@ function inlineImportsWithLineToImports(
     // We're only interested in the inlined import lines, ignore any
     // non-matching lines
     if (match) {
+      fragmentCollector.set(filename, rawSource);
       if (root) {
-        lineToImports.set(lineNumber, fragmentCollector);
+        lineToImports.set(lineNumber, new Map([...fragmentCollector]));
+        fragmentCollector.clear();
       }
-      fragmentCollector.set(filename, line);
     }
   }
 

--- a/lib/inline-imports.js
+++ b/lib/inline-imports.js
@@ -49,7 +49,8 @@ function* linesWithInlinedImportsOf(
       }
 
       const fragmentSource = fs.readFileSync(filename, 'utf8');
-      const line = inlineImports(
+      debugger;
+      const { inlineImports, lineToImports } = inlineImportsWithLineToImports(
         fragmentSource,
         {
           resolveImport: resolve,
@@ -59,7 +60,8 @@ function* linesWithInlinedImportsOf(
         },
         visited,
       );
-      yield { line, match: true, lineNumber, filename };
+
+      yield { line: inlineImports, match: true, lineNumber, filename, lineToImports };
     } else {
       yield { line, match: false, lineNumber };
     }
@@ -78,17 +80,32 @@ function inlineImportsWithLineToImports(fileContents, options = {}, visited = ne
   const inlineImportsResult = [];
   const lineToImports = new Map();
 
-  for (let { line, match, lineNumber, filename } of linesWithInlinedImportsOf(
-    fileContents,
-    options,
-    visited,
-  )) {
+  for (let {
+    line,
+    match,
+    lineNumber,
+    filename,
+    lineToImports: fragmentLineToImports,
+  } of linesWithInlinedImportsOf(fileContents, options, visited)) {
     inlineImportsResult.push(line);
 
     // We're only interested in the inlined import lines, ignore any
     // non-matching lines
     if (match) {
-      lineToImports.set(lineNumber, { filename, line });
+      let inlinedFragments = lineToImports.get(lineNumber);
+      if (inlinedFragments === undefined) {
+        inlinedFragments = new Map();
+        lineToImports.set(lineNumber, inlinedFragments);
+      }
+
+      // TODO: this is totally wrong, but **something** needs to happen here :P
+      fragmentLineToImports.forEach((_nestedLineNumber, inlinedFragmentsMap) => {
+        inlinedFragmentsMap.forEach((filename, source) => {
+          inlinedFragments.set(filename, source);
+        });
+      });
+
+      inlinedFragments.set(filename, line);
     }
   }
 

--- a/lib/inline-imports.js
+++ b/lib/inline-imports.js
@@ -105,20 +105,6 @@ function inlineImportsWithLineToImports(
       if (root) {
         lineToImports.set(lineNumber, fragmentCollector);
       }
-      // let inlinedFragments = lineToImports.get(lineNumber);
-      // if (inlinedFragments === undefined) {
-      //   inlinedFragments = new Map();
-      //   lineToImports.set(lineNumber, inlinedFragments);
-      // }
-
-      // // TODO: this is totally wrong, but **something** needs to happen here :P
-      // fragmentLineToImports.forEach((_nestedLineNumber, inlinedFragmentsMap) => {
-      //   inlinedFragmentsMap.forEach((filename, source) => {
-      //     inlinedFragments.set(filename, source);
-      //   });
-      // });
-
-      // inlinedFragments.set(filename, line);
       fragmentCollector.set(filename, line);
     }
   }

--- a/lib/inline-imports.js
+++ b/lib/inline-imports.js
@@ -103,7 +103,7 @@ function inlineImportsWithLineToImports(
     if (match) {
       fragmentCollector.set(filename, rawSource);
       if (root) {
-        lineToImports.set(lineNumber, new Map([...fragmentCollector]));
+        lineToImports.set(lineNumber, new Map(fragmentCollector));
         fragmentCollector.clear();
       }
     }

--- a/lib/inline-imports.js
+++ b/lib/inline-imports.js
@@ -9,6 +9,7 @@ function* linesWithInlinedImportsOf(
   fileContents,
   { resolveOptions = {}, resolveImport, fs, throwIfImportNotFound },
   visited,
+  fragmentCollector,
 ) {
   // TODO: I suspect we will need to implement a capable memoization plan, to ensure
   // performance in large code-bases, specifically when doing full code-base analysis,
@@ -41,7 +42,7 @@ function* linesWithInlinedImportsOf(
         }
         throw e;
       }
-
+      // Add the filename to the visited set, to ensure we don't inline the same file over again
       if (visited.has(filename)) {
         continue;
       } else {
@@ -49,7 +50,6 @@ function* linesWithInlinedImportsOf(
       }
 
       const fragmentSource = fs.readFileSync(filename, 'utf8');
-      debugger;
       const { inlineImports, lineToImports } = inlineImportsWithLineToImports(
         fragmentSource,
         {
@@ -59,6 +59,8 @@ function* linesWithInlinedImportsOf(
           },
         },
         visited,
+        fragmentCollector,
+        false,
       );
 
       yield { line: inlineImports, match: true, lineNumber, filename, lineToImports };
@@ -76,36 +78,48 @@ function* linesWithInlinedImportsOf(
  * @name inlineImportsWithLineToImports
  * @returns {inlineImports: string, lineToImports: Map<number, {filename: string, line: string}>}
  */
-function inlineImportsWithLineToImports(fileContents, options = {}, visited = new Set()) {
+function inlineImportsWithLineToImports(
+  fileContents,
+  options = {},
+  visited = new Set(),
+  fragmentCollector = new Map(),
+  root = true,
+  lineToImports = new Map(),
+) {
   const inlineImportsResult = [];
-  const lineToImports = new Map();
 
-  for (let {
-    line,
-    match,
-    lineNumber,
-    filename,
-    lineToImports: fragmentLineToImports,
-  } of linesWithInlinedImportsOf(fileContents, options, visited)) {
+  /** Ideally lineToImports should look like this:
+  // Map<lineNumber, Map<filename,source>>
+**/
+  for (let { line, match, lineNumber, filename } of linesWithInlinedImportsOf(
+    fileContents,
+    options,
+    visited,
+    fragmentCollector,
+  )) {
     inlineImportsResult.push(line);
 
     // We're only interested in the inlined import lines, ignore any
     // non-matching lines
     if (match) {
-      let inlinedFragments = lineToImports.get(lineNumber);
-      if (inlinedFragments === undefined) {
-        inlinedFragments = new Map();
-        lineToImports.set(lineNumber, inlinedFragments);
+      if (root) {
+        lineToImports.set(lineNumber, fragmentCollector);
       }
+      // let inlinedFragments = lineToImports.get(lineNumber);
+      // if (inlinedFragments === undefined) {
+      //   inlinedFragments = new Map();
+      //   lineToImports.set(lineNumber, inlinedFragments);
+      // }
 
-      // TODO: this is totally wrong, but **something** needs to happen here :P
-      fragmentLineToImports.forEach((_nestedLineNumber, inlinedFragmentsMap) => {
-        inlinedFragmentsMap.forEach((filename, source) => {
-          inlinedFragments.set(filename, source);
-        });
-      });
+      // // TODO: this is totally wrong, but **something** needs to happen here :P
+      // fragmentLineToImports.forEach((_nestedLineNumber, inlinedFragmentsMap) => {
+      //   inlinedFragmentsMap.forEach((filename, source) => {
+      //     inlinedFragments.set(filename, source);
+      //   });
+      // });
 
-      inlinedFragments.set(filename, line);
+      // inlinedFragments.set(filename, line);
+      fragmentCollector.set(filename, line);
     }
   }
 

--- a/lib/match-import.js
+++ b/lib/match-import.js
@@ -27,7 +27,6 @@ module.exports = function matchImport(value) {
     return null;
   }
 
-  //!!QUESTION: Why are we using REGEXP twice on the same value?
   const [, importIdentifierA, importIdentifierB] = value.match(IMPORT_REGEXP);
   if (importIdentifierA === undefined && importIdentifierB === undefined) {
     return null;

--- a/lib/match-import.js
+++ b/lib/match-import.js
@@ -26,6 +26,8 @@ module.exports = function matchImport(value) {
   if (matched === null) {
     return null;
   }
+
+  //!!QUESTION: Why are we using REGEXP twice on the same value?
   const [, importIdentifierA, importIdentifierB] = value.match(IMPORT_REGEXP);
   if (importIdentifierA === undefined && importIdentifierB === undefined) {
     return null;

--- a/lib/tests/gather-fragment-imports-test.js
+++ b/lib/tests/gather-fragment-imports-test.js
@@ -182,14 +182,14 @@ fragment FromDependency on User {
               'nested2',
               {
                 name: { value: 'nested2' },
-                loc: { filename: path.join(basedir, 'nested-1.graphql') },
+                loc: { filename: path.join(basedir, 'nested-2.graphql') },
               },
             ],
             [
               'nested3',
               {
                 name: { value: 'nested3' },
-                loc: { filename: path.join(basedir, 'nested-1.graphql') },
+                loc: { filename: path.join(basedir, 'nested-3.graphql') },
               },
             ],
           ]),

--- a/lib/tests/gather-fragment-imports-test.js
+++ b/lib/tests/gather-fragment-imports-test.js
@@ -119,7 +119,7 @@ fragment FromDependency on User {
     );
   });
 
-  it('handles double import', function () {
+  it.only('handles double import', function () {
     const result = gatherFragmentImports({
       source: fs.readFileSync(path.join(basedir, 'double-import.graphql'), 'utf8'),
       sourceLocation: path.join(basedir, 'double-import.graphql'),

--- a/lib/tests/gather-fragment-imports-test.js
+++ b/lib/tests/gather-fragment-imports-test.js
@@ -68,6 +68,13 @@ fragment nested3 on User {
 fragment parent on User {
   name
 }`;
+      project.files['nested-double.graphql'] = `
+#import './nested-1.graphql'
+#import './parent.graphql'
+
+fragment parent on User {
+  name
+}`;
       project.files['from-dependency.graphql'] = `
 #import 'my-dependency/_dependency-fragment.graphql'
 query {
@@ -119,7 +126,7 @@ fragment FromDependency on User {
     );
   });
 
-  it.only('handles double import', function () {
+  it('handles double import', function () {
     const result = gatherFragmentImports({
       source: fs.readFileSync(path.join(basedir, 'double-import.graphql'), 'utf8'),
       sourceLocation: path.join(basedir, 'double-import.graphql'),
@@ -196,6 +203,65 @@ fragment FromDependency on User {
         ],
       ]),
     );
+  });
+  it('handles nested imports, 3 fragments for import on line 2, 2 fragments on line 3', function () {
+    const result = gatherFragmentImports({
+      source: fs.readFileSync(path.join(basedir, 'nested-double.graphql'), 'utf8'),
+      sourceLocation: path.join(basedir, 'nested-double.graphql'),
+      resolveImport: require('resolve').sync,
+      fragmentParserGenerator: fakeParser,
+      throwIfImportNotFound: false,
+    });
+    const importOne = new Map([
+      [
+        2,
+        new Map([
+          [
+            'nested3',
+            {
+              name: { value: 'nested3' },
+              loc: { filename: path.join(basedir, 'nested-3.graphql') },
+            },
+          ],
+          [
+            'nested2',
+            {
+              name: { value: 'nested2' },
+              loc: { filename: path.join(basedir, 'nested-2.graphql') },
+            },
+          ],
+          [
+            'nested1',
+            {
+              name: { value: 'nested1' },
+              loc: { filename: path.join(basedir, 'nested-1.graphql') },
+            },
+          ],
+        ]),
+      ],
+    ]);
+    const importTwo = new Map([
+      [
+        3,
+        new Map([
+          [
+            'apple',
+            {
+              name: { value: 'apple' },
+              loc: { filename: path.join(basedir, 'apple.graphql') },
+            },
+          ],
+          [
+            'parent',
+            {
+              name: { value: 'parent' },
+              loc: { filename: path.join(basedir, 'parent.graphql') },
+            },
+          ],
+        ]),
+      ],
+    ]);
+    assert.deepEqual(result, new Map([...importOne, ...importTwo]));
   });
 
   it('handles imports from another package', function () {

--- a/lib/tests/inline-imports-test.js
+++ b/lib/tests/inline-imports-test.js
@@ -304,6 +304,7 @@ query {
     expect(lineToImports.size).to.eql(1);
     const apple = path.join(basedir, 'apple.graphql');
     const parent = path.join(basedir, 'parent.graphql');
+    expect(lineToImports.get(2).size).to.eql(2);
     expect(lineToImports.get(2).get(apple)).to.deep.eql('\nfragment apple on User {\n  name\n}');
     expect(lineToImports.get(2).get(parent)).to.deep.eql(
       '\n\nfragment apple on User {\n  name\n}\n\nfragment parent on User {\n  name\n}',

--- a/lib/tests/inline-imports-test.js
+++ b/lib/tests/inline-imports-test.js
@@ -270,7 +270,8 @@ query {
 
   it.only('`inlineImportsWithLineToImports` includes location information from transitive fragments', function () {
     const options = { resolveOptions: { basedir } };
-    assertProjectImports(options);
+    //!!TEMPORARY: this is annoying to deal with, so BEGONE
+    // assertProjectImports(options);
 
     const { inlineImports, lineToImports } = inlineImportsWithLineToImports(
       `
@@ -301,18 +302,12 @@ query {
   }
 }`);
 
-    debugger;
     expect(lineToImports.size).to.eql(1);
-    expect(lineToImports.get(2)).to.deep.eql(
-      new Map([
-        [
-          2,
-          {
-            filename: path.join(basedir, 'node_modules/my-dependency/_dependency-fragment.graphql'),
-            line: '\nfragment FromDependency on User {\n  name\n}',
-          },
-        ],
-      ]),
+    const apple = path.join(basedir, 'apple.graphql');
+    const parent = path.join(basedir, 'parent.graphql');
+    expect(lineToImports.get(2).get(apple)).to.deep.eql('\nfragment apple on User {\n  name\n}');
+    expect(lineToImports.get(2).get(parent)).to.deep.eql(
+      '\n\nfragment apple on User {\n  name\n}\n\nfragment parent on User {\n  name\n}',
     );
   });
 

--- a/lib/tests/inline-imports-test.js
+++ b/lib/tests/inline-imports-test.js
@@ -268,10 +268,9 @@ query {
     });
   });
 
-  it.only('`inlineImportsWithLineToImports` includes location information from transitive fragments', function () {
+  it('`inlineImportsWithLineToImports` includes location information from transitive fragments', function () {
     const options = { resolveOptions: { basedir } };
-    //!!TEMPORARY: this is annoying to deal with, so BEGONE
-    // assertProjectImports(options);
+    assertProjectImports(options);
 
     const { inlineImports, lineToImports } = inlineImportsWithLineToImports(
       `

--- a/lib/tests/inline-imports-test.js
+++ b/lib/tests/inline-imports-test.js
@@ -268,6 +268,54 @@ query {
     });
   });
 
+  it.only('`inlineImportsWithLineToImports` includes location information from transitive fragments', function () {
+    const options = { resolveOptions: { basedir } };
+    assertProjectImports(options);
+
+    const { inlineImports, lineToImports } = inlineImportsWithLineToImports(
+      `
+#import './parent.graphql'
+
+query {
+  myQuery {
+    ...parent
+  }
+}`,
+      options,
+    );
+
+    expect(inlineImports).to.eql(`
+
+
+fragment apple on User {
+  name
+}
+
+fragment parent on User {
+  name
+}
+
+query {
+  myQuery {
+    ...parent
+  }
+}`);
+
+    debugger;
+    expect(lineToImports.size).to.eql(1);
+    expect(lineToImports.get(2)).to.deep.eql(
+      new Map([
+        [
+          2,
+          {
+            filename: path.join(basedir, 'node_modules/my-dependency/_dependency-fragment.graphql'),
+            line: '\nfragment FromDependency on User {\n  name\n}',
+          },
+        ],
+      ]),
+    );
+  });
+
   it('`inlineImportsWithLineToImports` returns correctly for a query with no imported fragments', function () {
     const options = { resolveOptions: { basedir } };
     assertProjectImports(options);

--- a/lib/tests/inline-imports-test.js
+++ b/lib/tests/inline-imports-test.js
@@ -262,10 +262,14 @@ query {
 }`);
 
     expect(lineToImports.size).to.eql(1);
-    expect(lineToImports.get(2)).to.deep.eql({
-      filename: path.join(basedir, 'node_modules/my-dependency/_dependency-fragment.graphql'),
-      line: '\nfragment FromDependency on User {\n  name\n}',
-    });
+    expect(lineToImports.get(2)).to.deep.eql(
+      new Map([
+        [
+          path.join(basedir, 'node_modules/my-dependency/_dependency-fragment.graphql'),
+          '\nfragment FromDependency on User {\n  name\n}',
+        ],
+      ]),
+    );
   });
 
   it('`inlineImportsWithLineToImports` includes location information from transitive fragments', function () {
@@ -307,7 +311,7 @@ query {
     expect(lineToImports.get(2).size).to.eql(2);
     expect(lineToImports.get(2).get(apple)).to.deep.eql('\nfragment apple on User {\n  name\n}');
     expect(lineToImports.get(2).get(parent)).to.deep.eql(
-      '\n\nfragment apple on User {\n  name\n}\n\nfragment parent on User {\n  name\n}',
+      "\n#import './apple.graphql'\n\nfragment parent on User {\n  name\n}",
     );
   });
 


### PR DESCRIPTION
Previously, when `inlineImports`, `inlineImportsWithLineToImports`, or `lineToImports` (from `@graphql-fragment-import/lib/inline-imports`) were ran they eagerly inlined any fragments that were found recursively (which is exactly what we want!). However, when `lineToImports` (and `inlineImportsWithLineToImports`) were added so that we could expose the dependency relationships (specifically to associate all of the fragment "dependencies" of a given query file) we only reported the *first level* of fragment that we found. 

So for example, given a query structure like this `Root -> imports from fragA -> imports from fragB`, when `lineToImports` was called it would only report that `fragA` was imported from (and essentially ignored `fragB` since it was already inlined into `fragA`). This meant that the resulting query string was correct (all of the fragments were found) but since the dependency on `fragB` was missing, any systems that use that dependency information in order to ensure the root query is rebuilt if any dependent files are changed would end up being wrong if `fragB` was changed. 😩 
